### PR TITLE
Separate masked/unmasked token statistics and remove synthetic diffusion stage lines from heatmaps

### DIFF
--- a/collect_activations.py
+++ b/collect_activations.py
@@ -388,9 +388,9 @@ def compute_stats_for_batch(
     feats: torch.Tensor,
     attention_mask: torch.Tensor,
     top_m: int,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
-    Compute the three per-sequence statistics over the token dimension.
+    Compute the four per-sequence statistics over the token dimension.
 
     Args:
         feats:           [B, S, F]  SAE feature activations
@@ -401,6 +401,7 @@ def compute_stats_for_batch(
         stat1 - mean activation across all valid tokens
         stat2 - mean activation across the top-M tokens by value
         stat3 - fraction of valid tokens where the feature is active (> 0)
+        stat4 - variance of activation across all valid tokens
     """
     if feats.ndim != 3:
         raise ValueError(f"Expected feats shape [B, S, F], got {tuple(feats.shape)}")
@@ -427,7 +428,13 @@ def compute_stats_for_batch(
     # Stat 3: activation frequency (fraction of tokens where feature > 0)
     stat3 = ((feats > 0) & mask.unsqueeze(-1)).float().sum(dim=1) / valid_counts.unsqueeze(-1)
 
-    return stat1, stat2, stat3
+    # Stat 4: variance of activation across all valid tokens
+    # Var = E[x^2] - E[x]^2, computed only over valid (non-padding) tokens
+    masked_feats_sq = (feats ** 2) * mask.unsqueeze(-1)
+    mean_sq = masked_feats_sq.sum(dim=1) / valid_counts.unsqueeze(-1)  # [B, F]
+    stat4 = (mean_sq - stat1 ** 2).clamp(min=0.0)                      # [B, F]
+
+    return stat1, stat2, stat3, stat4
 
 
 # ---------------------------------------------------------------------------
@@ -469,11 +476,13 @@ class LayerStatsAccumulator:
         self.unmasked_sum_stat1 = _zero_buf()
         self.unmasked_sum_stat2 = _zero_buf()
         self.unmasked_sum_stat3 = _zero_buf()
+        self.unmasked_sum_stat4 = _zero_buf()
 
         # Running sums for masked tokens (token_type=1): {layer: [F, T]}
         self.masked_sum_stat1 = _zero_buf()
         self.masked_sum_stat2 = _zero_buf()
         self.masked_sum_stat3 = _zero_buf()
+        self.masked_sum_stat4 = _zero_buf()
 
         # Number of sequences contributing to each timestep, per token type
         self.unmasked_seq_count = torch.zeros(num_steps, dtype=torch.long)
@@ -499,6 +508,7 @@ class LayerStatsAccumulator:
         sum_s1: Dict[int, torch.Tensor],
         sum_s2: Dict[int, torch.Tensor],
         sum_s3: Dict[int, torch.Tensor],
+        sum_s4: Dict[int, torch.Tensor],
         seq_count: torch.Tensor,
         layer: int,
         feats_region: torch.Tensor,
@@ -508,10 +518,11 @@ class LayerStatsAccumulator:
         """Helper: compute stats and add to the given running-sum buffers."""
         if token_mask.sum().item() == 0:
             return
-        s1, s2, s3 = compute_stats_for_batch(feats_region, token_mask, self.top_m)
+        s1, s2, s3, s4 = compute_stats_for_batch(feats_region, token_mask, self.top_m)
         sum_s1[layer][:, t] += s1.sum(dim=0).cpu()
         sum_s2[layer][:, t] += s2.sum(dim=0).cpu()
         sum_s3[layer][:, t] += s3.sum(dim=0).cpu()
+        sum_s4[layer][:, t] += s4.sum(dim=0).cpu()
         seq_count[t] += feats_region.shape[0]
 
     def update(self, layer: int, feats: torch.Tensor) -> None:
@@ -542,22 +553,24 @@ class LayerStatsAccumulator:
         # Accumulate statistics for each token type
         self._accumulate(
             self.unmasked_sum_stat1, self.unmasked_sum_stat2, self.unmasked_sum_stat3,
+            self.unmasked_sum_stat4,
             self.unmasked_seq_count, layer, feats_region, unmasked_mask, t,
         )
         self._accumulate(
             self.masked_sum_stat1, self.masked_sum_stat2, self.masked_sum_stat3,
+            self.masked_sum_stat4,
             self.masked_seq_count, layer, feats_region, masked_mask, t,
         )
 
     def finalize(self) -> torch.Tensor:
         """
         Divide running sums by sequence counts to get per-timestep means.
-        Returns a tensor of shape [2, L, 3, F, T].
+        Returns a tensor of shape [2, L, 4, F, T].
             [0] = unmasked token statistics
             [1] = masked token statistics
         """
         num_layers = len(self.layers)
-        out = torch.zeros(2, num_layers, 3, self.feature_dim, self.num_steps, dtype=torch.float32)
+        out = torch.zeros(2, num_layers, 4, self.feature_dim, self.num_steps, dtype=torch.float32)
 
         unmasked_counts = self.unmasked_seq_count.clamp(min=1).float()  # [T]
         masked_counts   = self.masked_seq_count.clamp(min=1).float()    # [T]
@@ -567,11 +580,13 @@ class LayerStatsAccumulator:
             out[0, i, 0] = self.unmasked_sum_stat1[layer] / unmasked_counts.unsqueeze(0)
             out[0, i, 1] = self.unmasked_sum_stat2[layer] / unmasked_counts.unsqueeze(0)
             out[0, i, 2] = self.unmasked_sum_stat3[layer] / unmasked_counts.unsqueeze(0)
+            out[0, i, 3] = self.unmasked_sum_stat4[layer] / unmasked_counts.unsqueeze(0)
 
             # Masked (token_type = 1)
             out[1, i, 0] = self.masked_sum_stat1[layer] / masked_counts.unsqueeze(0)
             out[1, i, 1] = self.masked_sum_stat2[layer] / masked_counts.unsqueeze(0)
             out[1, i, 2] = self.masked_sum_stat3[layer] / masked_counts.unsqueeze(0)
+            out[1, i, 3] = self.masked_sum_stat4[layer] / masked_counts.unsqueeze(0)
 
         return out
 
@@ -669,16 +684,17 @@ def save_outputs(
     unmasked_counts: torch.Tensor,
     masked_counts: torch.Tensor,
 ) -> None:
-    """Save the [2, L, 3, F, T] tensor plus metadata to out_dir."""
+    """Save the [2, L, 4, F, T] tensor plus metadata to out_dir."""
     os.makedirs(out_dir, exist_ok=True)
 
     # Raw tensor for fast loading
-    torch.save(tensor, os.path.join(out_dir, "layer_stats_2xLx3xFxT.pt"))
+    torch.save(tensor, os.path.join(out_dir, "layer_stats_2xLx4xFxT.pt"))
 
     stats_order = [
         "all_token_average",
         f"top_{args.top_m}_token_average",
         "activation_frequency",
+        "activation_variance",
     ]
 
     # Full bundle with config for reproducibility

--- a/collect_activations.py
+++ b/collect_activations.py
@@ -436,54 +436,89 @@ def compute_stats_for_batch(
 
 class LayerStatsAccumulator:
     """
-    Accumulates the three statistics across all text sequences and diffusion timesteps.
+    Accumulates the three statistics across all text sequences and diffusion timesteps,
+    separately for unmasked tokens and masked ([MASK]) tokens.
 
-    Internal buffers have shape [F, T] per layer per statistic.
-    Finalize() returns a tensor of shape [L, 3, F, T].
+    Internal buffers have shape [F, T] per layer per statistic per token type.
+    Finalize() returns a tensor of shape [2, L, 3, F, T] where:
+        dim 0: token type  (0 = unmasked, 1 = masked)
+        dim 1: layer index
+        dim 2: statistic   (0 = all_token_avg, 1 = top_m_avg, 2 = activation_freq)
+        dim 3: SAE feature index
+        dim 4: diffusion timestep
     """
 
-    def __init__(self, layers: List[int], feature_dim: int, num_steps: int, top_m: int):
+    def __init__(self, layers: List[int], feature_dim: int, num_steps: int, top_m: int, mask_token_id: int):
         self.layers = list(layers)
         self.feature_dim = int(feature_dim)
         self.num_steps = int(num_steps)
         self.top_m = int(top_m)
+        self.mask_token_id = int(mask_token_id)
 
         # State set before each forward pass by replay_history_and_collect
         self.current_timestep: Optional[int] = None
+        self.current_input_ids: Optional[torch.Tensor] = None
         self.current_attention_mask: Optional[torch.Tensor] = None
         self.current_region_start: int = 0
         self.current_region_end: Optional[int] = None
 
-        # Running sums: {layer: [F, T]}
-        self.sum_stat1: Dict[int, torch.Tensor] = {
-            l: torch.zeros(feature_dim, num_steps, dtype=torch.float32) for l in self.layers
-        }
-        self.sum_stat2: Dict[int, torch.Tensor] = {
-            l: torch.zeros(feature_dim, num_steps, dtype=torch.float32) for l in self.layers
-        }
-        self.sum_stat3: Dict[int, torch.Tensor] = {
-            l: torch.zeros(feature_dim, num_steps, dtype=torch.float32) for l in self.layers
-        }
-        # Number of sequences that contributed to each timestep column
-        self.seq_count_by_timestep = torch.zeros(num_steps, dtype=torch.long)
+        def _zero_buf():
+            return {l: torch.zeros(feature_dim, num_steps, dtype=torch.float32) for l in self.layers}
+
+        # Running sums for unmasked tokens (token_type=0): {layer: [F, T]}
+        self.unmasked_sum_stat1 = _zero_buf()
+        self.unmasked_sum_stat2 = _zero_buf()
+        self.unmasked_sum_stat3 = _zero_buf()
+
+        # Running sums for masked tokens (token_type=1): {layer: [F, T]}
+        self.masked_sum_stat1 = _zero_buf()
+        self.masked_sum_stat2 = _zero_buf()
+        self.masked_sum_stat3 = _zero_buf()
+
+        # Number of sequences contributing to each timestep, per token type
+        self.unmasked_seq_count = torch.zeros(num_steps, dtype=torch.long)
+        self.masked_seq_count   = torch.zeros(num_steps, dtype=torch.long)
 
     def start_timestep(
         self,
         timestep: int,
+        input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
         region_start: int,
         region_end: Optional[int] = None,
     ) -> None:
         """Called once per (text, timestep) pair before the forward pass."""
         self.current_timestep = int(timestep)
+        self.current_input_ids = input_ids
         self.current_attention_mask = attention_mask
         self.current_region_start = int(region_start)
         self.current_region_end = None if region_end is None else int(region_end)
 
+    def _accumulate(
+        self,
+        sum_s1: Dict[int, torch.Tensor],
+        sum_s2: Dict[int, torch.Tensor],
+        sum_s3: Dict[int, torch.Tensor],
+        seq_count: torch.Tensor,
+        layer: int,
+        feats_region: torch.Tensor,
+        token_mask: torch.Tensor,
+        t: int,
+    ) -> None:
+        """Helper: compute stats and add to the given running-sum buffers."""
+        if token_mask.sum().item() == 0:
+            return
+        s1, s2, s3 = compute_stats_for_batch(feats_region, token_mask, self.top_m)
+        sum_s1[layer][:, t] += s1.sum(dim=0).cpu()
+        sum_s2[layer][:, t] += s2.sum(dim=0).cpu()
+        sum_s3[layer][:, t] += s3.sum(dim=0).cpu()
+        seq_count[t] += feats_region.shape[0]
+
     def update(self, layer: int, feats: torch.Tensor) -> None:
         """
         Called inside the forward hook with raw SAE features [B, S, F].
-        Slices to the requested token region and accumulates statistics.
+        Splits the token region into unmasked vs masked positions and
+        accumulates statistics for each type separately.
         """
         if self.current_timestep is None or self.current_attention_mask is None:
             raise RuntimeError("start_timestep() must be called before the forward pass.")
@@ -493,35 +528,50 @@ class LayerStatsAccumulator:
         if end <= start:
             return
 
-        feats_region = feats[:, start:end, :].float()
-        mask_region = self.current_attention_mask[:, start:end].bool()
+        feats_region  = feats[:, start:end, :].float()             # [B, S', F]
+        attn_region   = self.current_attention_mask[:, start:end].bool()  # [B, S']
+        ids_region    = self.current_input_ids[:, start:end]        # [B, S']
 
-        # Skip if no valid tokens in the region (e.g. very short prompt)
-        if mask_region.sum().item() == 0:
-            return
-
-        s1, s2, s3 = compute_stats_for_batch(feats_region, mask_region, self.top_m)
+        # Boolean masks: True where a token is unmasked / masked
+        is_mask_token  = (ids_region == self.mask_token_id)         # [B, S']
+        unmasked_mask  = attn_region & ~is_mask_token               # valid + not [MASK]
+        masked_mask    = attn_region & is_mask_token                # valid + [MASK]
 
         t = self.current_timestep
-        # Sum over the batch dimension; finalize() divides by seq count later
-        self.sum_stat1[layer][:, t] += s1.sum(dim=0).cpu()
-        self.sum_stat2[layer][:, t] += s2.sum(dim=0).cpu()
-        self.sum_stat3[layer][:, t] += s3.sum(dim=0).cpu()
-        self.seq_count_by_timestep[t] += feats_region.shape[0]
+
+        # Accumulate statistics for each token type
+        self._accumulate(
+            self.unmasked_sum_stat1, self.unmasked_sum_stat2, self.unmasked_sum_stat3,
+            self.unmasked_seq_count, layer, feats_region, unmasked_mask, t,
+        )
+        self._accumulate(
+            self.masked_sum_stat1, self.masked_sum_stat2, self.masked_sum_stat3,
+            self.masked_seq_count, layer, feats_region, masked_mask, t,
+        )
 
     def finalize(self) -> torch.Tensor:
         """
         Divide running sums by sequence counts to get per-timestep means.
-        Returns a tensor of shape [L, 3, F, T].
+        Returns a tensor of shape [2, L, 3, F, T].
+            [0] = unmasked token statistics
+            [1] = masked token statistics
         """
         num_layers = len(self.layers)
-        out = torch.zeros(num_layers, 3, self.feature_dim, self.num_steps, dtype=torch.float32)
-        counts = self.seq_count_by_timestep.clamp(min=1).float()  # [T]
+        out = torch.zeros(2, num_layers, 3, self.feature_dim, self.num_steps, dtype=torch.float32)
+
+        unmasked_counts = self.unmasked_seq_count.clamp(min=1).float()  # [T]
+        masked_counts   = self.masked_seq_count.clamp(min=1).float()    # [T]
 
         for i, layer in enumerate(self.layers):
-            out[i, 0] = self.sum_stat1[layer] / counts.unsqueeze(0)
-            out[i, 1] = self.sum_stat2[layer] / counts.unsqueeze(0)
-            out[i, 2] = self.sum_stat3[layer] / counts.unsqueeze(0)
+            # Unmasked (token_type = 0)
+            out[0, i, 0] = self.unmasked_sum_stat1[layer] / unmasked_counts.unsqueeze(0)
+            out[0, i, 1] = self.unmasked_sum_stat2[layer] / unmasked_counts.unsqueeze(0)
+            out[0, i, 2] = self.unmasked_sum_stat3[layer] / unmasked_counts.unsqueeze(0)
+
+            # Masked (token_type = 1)
+            out[1, i, 0] = self.masked_sum_stat1[layer] / masked_counts.unsqueeze(0)
+            out[1, i, 1] = self.masked_sum_stat2[layer] / masked_counts.unsqueeze(0)
+            out[1, i, 2] = self.masked_sum_stat3[layer] / masked_counts.unsqueeze(0)
 
         return out
 
@@ -575,7 +625,8 @@ def replay_history_and_collect(
 ) -> None:
     """
     Re-run the model once per diffusion timestep using the token sequences
-    stored in history. The forward hooks collect SAE features at each step.
+    stored in history. The forward hooks collect SAE features at each step,
+    split by unmasked vs masked token positions.
 
     token_scope:
         'generated' - statistics computed only over the newly generated tokens
@@ -596,6 +647,7 @@ def replay_history_and_collect(
 
         accumulator.start_timestep(
             timestep=timestep,
+            input_ids=input_ids,
             attention_mask=attention_mask,
             region_start=region_start,
             region_end=region_end,
@@ -614,24 +666,29 @@ def save_outputs(
     args: argparse.Namespace,
     layers: List[int],
     tensor: torch.Tensor,
-    counts: torch.Tensor,
+    unmasked_counts: torch.Tensor,
+    masked_counts: torch.Tensor,
 ) -> None:
-    """Save the [L, 3, F, T] tensor plus metadata to out_dir."""
+    """Save the [2, L, 3, F, T] tensor plus metadata to out_dir."""
     os.makedirs(out_dir, exist_ok=True)
 
     # Raw tensor for fast loading
-    torch.save(tensor, os.path.join(out_dir, "layer_stats_Lx3xFxT.pt"))
+    torch.save(tensor, os.path.join(out_dir, "layer_stats_2xLx3xFxT.pt"))
+
+    stats_order = [
+        "all_token_average",
+        f"top_{args.top_m}_token_average",
+        "activation_frequency",
+    ]
 
     # Full bundle with config for reproducibility
     bundle = {
         "tensor": tensor,
         "layers": layers,
-        "stats_order": [
-            "all_token_average",
-            f"top_{args.top_m}_token_average",
-            "activation_frequency",
-        ],
-        "count_by_timestep": counts,
+        "token_types": ["unmasked", "masked"],
+        "stats_order": stats_order,
+        "unmasked_count_by_timestep": unmasked_counts,
+        "masked_count_by_timestep": masked_counts,
         "config": vars(args),
     }
     torch.save(bundle, os.path.join(out_dir, "layer_stats_bundle.pt"))
@@ -640,12 +697,10 @@ def save_outputs(
     metadata = {
         "layers": layers,
         "tensor_shape": list(tensor.shape),
-        "stats_order": [
-            "all_token_average",
-            f"top_{args.top_m}_token_average",
-            "activation_frequency",
-        ],
-        "count_by_timestep": counts.tolist(),
+        "token_types": ["unmasked", "masked"],
+        "stats_order": stats_order,
+        "unmasked_count_by_timestep": unmasked_counts.tolist(),
+        "masked_count_by_timestep": masked_counts.tolist(),
         "config": vars(args),
     }
     with open(os.path.join(out_dir, "metadata.json"), "w", encoding="utf-8") as f:
@@ -686,11 +741,17 @@ def main() -> None:
     print(f"Loaded SAEs for layers: {args.layers}")
 
     feature_dim = next(iter(saes.values())).dict_size
+    mask_token_id = tokenizer.mask_token_id
+    if mask_token_id is None:
+        raise RuntimeError("Tokenizer has no mask_token_id. Cannot separate masked/unmasked tokens.")
+    print(f"Mask token id: {mask_token_id}")
+
     accumulator = LayerStatsAccumulator(
         layers=args.layers,
         feature_dim=feature_dim,
         num_steps=args.steps,
         top_m=args.top_m,
+        mask_token_id=mask_token_id,
     )
 
     processed = 0
@@ -724,12 +785,14 @@ def main() -> None:
         args=args,
         layers=args.layers,
         tensor=final_tensor,
-        counts=accumulator.seq_count_by_timestep,
+        unmasked_counts=accumulator.unmasked_seq_count,
+        masked_counts=accumulator.masked_seq_count,
     )
 
     print("Done.")
     print(f"Processed texts : {processed}")
-    print(f"Final tensor shape : {tuple(final_tensor.shape)}  (L x 3 x F x T)")
+    print(f"Final tensor shape : {tuple(final_tensor.shape)}  (2 x L x 3 x F x T)")
+    print(f"  dim 0: token type (0=unmasked, 1=masked)")
     print(f"Outputs written to : {args.out_dir}")
 
 

--- a/collect_activations.py
+++ b/collect_activations.py
@@ -447,7 +447,7 @@ class LayerStatsAccumulator:
     separately for unmasked tokens and masked ([MASK]) tokens.
 
     Internal buffers have shape [F, T] per layer per statistic per token type.
-    Finalize() returns a tensor of shape [2, L, 3, F, T] where:
+    Finalize() returns a tensor of shape [2, L, 4, F, T] where:
         dim 0: token type  (0 = unmasked, 1 = masked)
         dim 1: layer index
         dim 2: statistic   (0 = all_token_avg, 1 = top_m_avg, 2 = activation_freq)
@@ -807,7 +807,7 @@ def main() -> None:
 
     print("Done.")
     print(f"Processed texts : {processed}")
-    print(f"Final tensor shape : {tuple(final_tensor.shape)}  (2 x L x 3 x F x T)")
+    print(f"Final tensor shape : {tuple(final_tensor.shape)}  (2 x L x 4 x F x T)")
     print(f"  dim 0: token type (0=unmasked, 1=masked)")
     print(f"Outputs written to : {args.out_dir}")
 

--- a/visualize_activations.py
+++ b/visualize_activations.py
@@ -29,9 +29,10 @@ STAT_NAMES = [
     "All-token Average",
     "Top-M Token Average",
     "Activation Frequency",
+    "Activation Variance",
 ]
 
-STAT_SHORT = ["avg_all", "avg_topm", "freq"]
+STAT_SHORT = ["avg_all", "avg_topm", "freq", "var"]
 
 
 # ---------------------------------------------------------------------------
@@ -351,7 +352,7 @@ def main() -> None:
             for s in range(num_stats):
                 activation = tensor[tt, i, s].numpy()   # [F, T]
                 plot_heatmap(
-                    activation=activation,
+                    activation=activation.copy(),
                     layer=layer,
                     stat_idx=s,
                     out_dir=tt_dir,
@@ -360,7 +361,7 @@ def main() -> None:
                     colormap=args.colormap,
                 )
                 plot_heatmap_unsorted(
-                    activation=activation,
+                    activation=activation.copy(),
                     layer=layer,
                     stat_idx=s,
                     out_dir=tt_dir,

--- a/visualize_activations.py
+++ b/visualize_activations.py
@@ -1,10 +1,11 @@
 """
 visualize_activations.py
 
-Loads the [L x 3 x F x T] activation tensor produced by collect_activations.py
-and generates two sets of plots:
+Loads the [L x 3 x F x T] or [2 x L x 3 x F x T] activation tensor produced
+by collect_activations.py and generates two sets of plots:
 
-  1. Heatmaps (3 x L):  features (sorted by peak time) vs diffusion timestep
+  1. Heatmaps (3 x L): features (sorted by peak time) vs diffusion timestep
+                       features (unsorted, original index) vs diffusion timestep
   2. Histograms (3 x L): distribution of peak times across all features
 
 Usage:
@@ -90,12 +91,12 @@ def parse_args() -> argparse.Namespace:
 def load_data(args: argparse.Namespace):
     """
     Returns:
-        tensor: [L, 3, F, T]  float32
+        tensor: [L, 3, F, T] or [2, L, 3, F, T]  float32
         layers: list of int, length L
     """
     if args.bundle:
         bundle = torch.load(args.bundle, map_location="cpu", weights_only=False)
-        tensor = bundle["tensor"]           # [L, 3, F, T]
+        tensor = bundle["tensor"]
         layers = list(bundle["layers"])
     else:
         tensor = torch.load(args.tensor, map_location="cpu", weights_only=False)
@@ -104,13 +105,11 @@ def load_data(args: argparse.Namespace):
         layers = list(args.layers)
 
     if tensor.ndim == 4:
-        # Old format [L, 3, F, T]: verify layer count
         if tensor.shape[0] != len(layers):
             raise ValueError(
                 f"Tensor has {tensor.shape[0]} layers but {len(layers)} layer indices were provided."
             )
     elif tensor.ndim == 5:
-        # New format [2, L, 3, F, T]: verify layer count on dim 1
         if tensor.shape[1] != len(layers):
             raise ValueError(
                 f"Tensor has {tensor.shape[1]} layers but {len(layers)} layer indices were provided."
@@ -171,7 +170,7 @@ def plot_heatmap(
     colormap: str,
 ) -> None:
     """
-    Plot a single heatmap of features (sorted by peak time) vs diffusion timestep.
+    Plot a heatmap of features sorted by peak diffusion time vs diffusion timestep.
 
     Args:
         activation: [F, T]
@@ -180,16 +179,12 @@ def plot_heatmap(
 
     # Optionally restrict to the top-N features by mean activation
     if top_features is not None and top_features < F:
-        mean_act = activation.mean(axis=1)          # [F]
+        mean_act = activation.mean(axis=1)
         top_idx = np.argsort(mean_act)[-top_features:]
         activation = activation[top_idx]
         F = top_features
 
     sorted_act, _ = sort_features_by_peak_time(activation)
-
-    # Clip colormap range to 99th percentile to prevent outliers from washing out the plot
-    vmax = np.percentile(sorted_act[sorted_act > 0], 99) if (sorted_act > 0).any() else 1.0
-    vmin = 0.0
 
     fig, ax = plt.subplots(figsize=(10, 6))
     im = ax.imshow(
@@ -198,10 +193,8 @@ def plot_heatmap(
         origin="lower",
         cmap=colormap,
         interpolation="nearest",
-        vmin=vmin,
-        vmax=vmax,
     )
-    fig.colorbar(im, ax=ax, shrink=0.8, label=f"{STAT_NAMES[stat_idx]} (clipped at 99th pct)")
+    fig.colorbar(im, ax=ax, shrink=0.8, label=STAT_NAMES[stat_idx])
 
     ax.set_title(
         f"Layer {layer} — {STAT_NAMES[stat_idx]}\n"
@@ -215,7 +208,6 @@ def plot_heatmap(
     ax.set_xticks(ticks)
     ax.xaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: str(int(x))))
 
-    # Annotate y-axis with approximate peak-time thirds
     thirds = [0, F // 3, 2 * F // 3, F - 1]
     ax.set_yticks(thirds)
     ax.set_yticklabels([f"{v}" for v in thirds])
@@ -238,7 +230,7 @@ def plot_heatmap_unsorted(
     token_type_name: str,
 ) -> None:
     """
-    Plot a heatmap of features in their original (unsorted) order vs diffusion timestep.
+    Plot a heatmap of features in their original (unsorted) index order vs diffusion timestep.
     This allows direct feature index comparison across different plots and token types.
 
     Args:
@@ -253,10 +245,6 @@ def plot_heatmap_unsorted(
         activation = activation[top_idx]
         F = top_features
 
-    # Clip colormap range to 99th percentile to prevent outliers from washing out the plot
-    vmax = np.percentile(activation[activation > 0], 99) if (activation > 0).any() else 1.0
-    vmin = 0.0
-
     fig, ax = plt.subplots(figsize=(10, 6))
     im = ax.imshow(
         activation,
@@ -264,10 +252,8 @@ def plot_heatmap_unsorted(
         origin="lower",
         cmap=colormap,
         interpolation="nearest",
-        vmin=vmin,
-        vmax=vmax,
     )
-    fig.colorbar(im, ax=ax, shrink=0.8, label=f"{STAT_NAMES[stat_idx]} (clipped at 99th pct)")
+    fig.colorbar(im, ax=ax, shrink=0.8, label=STAT_NAMES[stat_idx])
 
     ax.set_title(
         f"Layer {layer} — {STAT_NAMES[stat_idx]} [{token_type_name}]\n"
@@ -342,7 +328,6 @@ def main() -> None:
 
     # Support both old [L, 3, F, T] and new [2, L, 3, F, T] tensor shapes.
     if tensor.ndim == 4:
-        # Old format: wrap in a fake token_type dimension for uniform handling
         tensor = tensor.unsqueeze(0)
         token_type_names = ["all"]
     elif tensor.ndim == 5:
@@ -356,10 +341,7 @@ def main() -> None:
     print(f"Token types: {token_type_names}")
 
     # ------------------------------------------------------------------
-    # 1. Heatmaps  (token_types x 3 x L)
-    #    Two variants per (token_type, layer, stat):
-    #      a) sorted by peak time  — reveals temporal specialization ordering
-    #      b) unsorted (original feature index order) — allows cross-plot comparison
+    # 1. Heatmaps: sorted + unsorted
     # ------------------------------------------------------------------
     print("\nGenerating heatmaps...")
     for tt, tt_name in enumerate(token_type_names):
@@ -368,7 +350,6 @@ def main() -> None:
         for i, layer in enumerate(layers):
             for s in range(num_stats):
                 activation = tensor[tt, i, s].numpy()   # [F, T]
-                # Sorted heatmap
                 plot_heatmap(
                     activation=activation,
                     layer=layer,
@@ -378,7 +359,6 @@ def main() -> None:
                     dpi=args.dpi,
                     colormap=args.colormap,
                 )
-                # Unsorted heatmap (features in original index order)
                 plot_heatmap_unsorted(
                     activation=activation,
                     layer=layer,
@@ -391,7 +371,7 @@ def main() -> None:
                 )
 
     # ------------------------------------------------------------------
-    # 2. Peak time histograms  (token_types x 3 x L)
+    # 2. Peak time histograms
     # ------------------------------------------------------------------
     print("\nGenerating peak time histograms...")
     for tt, tt_name in enumerate(token_type_names):
@@ -407,7 +387,7 @@ def main() -> None:
                     dpi=args.dpi,
                 )
 
-    total = num_token_types * 3 * L * num_stats  # sorted + unsorted heatmaps + histograms
+    total = num_token_types * 3 * L * num_stats
     print(f"\nDone. {total} plots saved under: {args.out_dir}/")
 
 

--- a/visualize_activations.py
+++ b/visualize_activations.py
@@ -103,12 +103,20 @@ def load_data(args: argparse.Namespace):
             raise ValueError("--layers is required when loading a raw tensor with --tensor.")
         layers = list(args.layers)
 
-    if tensor.ndim != 4:
-        raise ValueError(f"Expected tensor shape [L, 3, F, T], got {tuple(tensor.shape)}")
-    if tensor.shape[0] != len(layers):
-        raise ValueError(
-            f"Tensor has {tensor.shape[0]} layers but {len(layers)} layer indices were provided."
-        )
+    if tensor.ndim == 4:
+        # Old format [L, 3, F, T]: verify layer count
+        if tensor.shape[0] != len(layers):
+            raise ValueError(
+                f"Tensor has {tensor.shape[0]} layers but {len(layers)} layer indices were provided."
+            )
+    elif tensor.ndim == 5:
+        # New format [2, L, 3, F, T]: verify layer count on dim 1
+        if tensor.shape[1] != len(layers):
+            raise ValueError(
+                f"Tensor has {tensor.shape[1]} layers but {len(layers)} layer indices were provided."
+            )
+    else:
+        raise ValueError(f"Expected tensor shape [L, 3, F, T] or [2, L, 3, F, T], got {tuple(tensor.shape)}")
 
     return tensor.float(), layers
 
@@ -179,6 +187,10 @@ def plot_heatmap(
 
     sorted_act, _ = sort_features_by_peak_time(activation)
 
+    # Clip colormap range to 99th percentile to prevent outliers from washing out the plot
+    vmax = np.percentile(sorted_act[sorted_act > 0], 99) if (sorted_act > 0).any() else 1.0
+    vmin = 0.0
+
     fig, ax = plt.subplots(figsize=(10, 6))
     im = ax.imshow(
         sorted_act,
@@ -186,8 +198,10 @@ def plot_heatmap(
         origin="lower",
         cmap=colormap,
         interpolation="nearest",
+        vmin=vmin,
+        vmax=vmax,
     )
-    fig.colorbar(im, ax=ax, shrink=0.8, label=STAT_NAMES[stat_idx])
+    fig.colorbar(im, ax=ax, shrink=0.8, label=f"{STAT_NAMES[stat_idx]} (clipped at 99th pct)")
 
     ax.set_title(
         f"Layer {layer} — {STAT_NAMES[stat_idx]}\n"
@@ -208,6 +222,67 @@ def plot_heatmap(
 
     plt.tight_layout()
     fname = os.path.join(out_dir, f"heatmap_L{layer}_{STAT_SHORT[stat_idx]}.png")
+    fig.savefig(fname, dpi=dpi)
+    plt.close(fig)
+    print(f"  Saved: {fname}")
+
+
+def plot_heatmap_unsorted(
+    activation: np.ndarray,
+    layer: int,
+    stat_idx: int,
+    out_dir: str,
+    top_features: Optional[int],
+    dpi: int,
+    colormap: str,
+    token_type_name: str,
+) -> None:
+    """
+    Plot a heatmap of features in their original (unsorted) order vs diffusion timestep.
+    This allows direct feature index comparison across different plots and token types.
+
+    Args:
+        activation: [F, T]
+    """
+    F, T = activation.shape
+
+    # Optionally restrict to the top-N features by mean activation
+    if top_features is not None and top_features < F:
+        mean_act = activation.mean(axis=1)
+        top_idx = np.argsort(mean_act)[-top_features:]
+        activation = activation[top_idx]
+        F = top_features
+
+    # Clip colormap range to 99th percentile to prevent outliers from washing out the plot
+    vmax = np.percentile(activation[activation > 0], 99) if (activation > 0).any() else 1.0
+    vmin = 0.0
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    im = ax.imshow(
+        activation,
+        aspect="auto",
+        origin="lower",
+        cmap=colormap,
+        interpolation="nearest",
+        vmin=vmin,
+        vmax=vmax,
+    )
+    fig.colorbar(im, ax=ax, shrink=0.8, label=f"{STAT_NAMES[stat_idx]} (clipped at 99th pct)")
+
+    ax.set_title(
+        f"Layer {layer} — {STAT_NAMES[stat_idx]} [{token_type_name}]\n"
+        f"Features in original order  ({F} features shown)",
+        fontsize=11,
+    )
+    ax.set_xlabel("Diffusion Timestep")
+    ax.set_ylabel("Feature Index")
+
+    ticks = _timestep_ticks(T)
+    ax.set_xticks(ticks)
+    ax.xaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: str(int(x))))
+
+    plt.tight_layout()
+    fname = os.path.join(out_dir, f"heatmap_unsorted_L{layer}_{STAT_SHORT[stat_idx]}.png")
     fig.savefig(fname, dpi=dpi)
     plt.close(fig)
     print(f"  Saved: {fname}")
@@ -243,13 +318,9 @@ def plot_peak_time_histogram(
     ticks = _timestep_ticks(T)
     ax.set_xticks(ticks)
 
-    # Draw vertical lines at the diffusion stage boundaries (thirds)
-    for boundary in [T // 3, 2 * T // 3]:
-        ax.axvline(boundary, color="tomato", linestyle="--", linewidth=1.0, alpha=0.7)
-
-    ax.text(T // 6,       ax.get_ylim()[1] * 0.92, "Early",  ha="center", color="tomato", fontsize=9)
-    ax.text(T // 2,       ax.get_ylim()[1] * 0.92, "Middle", ha="center", color="tomato", fontsize=9)
-    ax.text(5 * T // 6,   ax.get_ylim()[1] * 0.92, "Late",   ha="center", color="tomato", fontsize=9)
+    # Vertical lines at T/3 and 2T/3 diffusion stage boundaries are intentionally
+    # omitted — we want to see whether the features themselves cluster at stage
+    # boundaries rather than being guided by synthetic reference lines.
 
     plt.tight_layout()
     fname = os.path.join(out_dir, f"hist_peak_L{layer}_{STAT_SHORT[stat_idx]}.png")
@@ -268,44 +339,76 @@ def main() -> None:
 
     print("Loading activation tensor...")
     tensor, layers = load_data(args)
-    L, num_stats, F, T = tensor.shape
-    print(f"Tensor shape: {tuple(tensor.shape)}  (L={L}, stats=3, F={F}, T={T})")
+
+    # Support both old [L, 3, F, T] and new [2, L, 3, F, T] tensor shapes.
+    if tensor.ndim == 4:
+        # Old format: wrap in a fake token_type dimension for uniform handling
+        tensor = tensor.unsqueeze(0)
+        token_type_names = ["all"]
+    elif tensor.ndim == 5:
+        token_type_names = ["unmasked", "masked"]
+    else:
+        raise ValueError(f"Unexpected tensor ndim={tensor.ndim}, expected 4 or 5.")
+
+    num_token_types, L, num_stats, F, T = tensor.shape
+    print(f"Tensor shape: {tuple(tensor.shape)}  (token_types={num_token_types}, L={L}, stats=3, F={F}, T={T})")
     print(f"Layers: {layers}")
+    print(f"Token types: {token_type_names}")
 
     # ------------------------------------------------------------------
-    # 1. Heatmaps  (3 x L)
+    # 1. Heatmaps  (token_types x 3 x L)
+    #    Two variants per (token_type, layer, stat):
+    #      a) sorted by peak time  — reveals temporal specialization ordering
+    #      b) unsorted (original feature index order) — allows cross-plot comparison
     # ------------------------------------------------------------------
     print("\nGenerating heatmaps...")
-    for i, layer in enumerate(layers):
-        for s in range(num_stats):
-            activation = tensor[i, s].numpy()   # [F, T]
-            plot_heatmap(
-                activation=activation,
-                layer=layer,
-                stat_idx=s,
-                out_dir=args.out_dir,
-                top_features=args.top_features,
-                dpi=args.dpi,
-                colormap=args.colormap,
-            )
+    for tt, tt_name in enumerate(token_type_names):
+        tt_dir = os.path.join(args.out_dir, tt_name)
+        os.makedirs(tt_dir, exist_ok=True)
+        for i, layer in enumerate(layers):
+            for s in range(num_stats):
+                activation = tensor[tt, i, s].numpy()   # [F, T]
+                # Sorted heatmap
+                plot_heatmap(
+                    activation=activation,
+                    layer=layer,
+                    stat_idx=s,
+                    out_dir=tt_dir,
+                    top_features=args.top_features,
+                    dpi=args.dpi,
+                    colormap=args.colormap,
+                )
+                # Unsorted heatmap (features in original index order)
+                plot_heatmap_unsorted(
+                    activation=activation,
+                    layer=layer,
+                    stat_idx=s,
+                    out_dir=tt_dir,
+                    top_features=args.top_features,
+                    dpi=args.dpi,
+                    colormap=args.colormap,
+                    token_type_name=tt_name,
+                )
 
     # ------------------------------------------------------------------
-    # 2. Peak time histograms  (3 x L)
+    # 2. Peak time histograms  (token_types x 3 x L)
     # ------------------------------------------------------------------
     print("\nGenerating peak time histograms...")
-    for i, layer in enumerate(layers):
-        for s in range(num_stats):
-            activation = tensor[i, s].numpy()   # [F, T]
-            plot_peak_time_histogram(
-                activation=activation,
-                layer=layer,
-                stat_idx=s,
-                out_dir=args.out_dir,
-                dpi=args.dpi,
-            )
+    for tt, tt_name in enumerate(token_type_names):
+        tt_dir = os.path.join(args.out_dir, tt_name)
+        for i, layer in enumerate(layers):
+            for s in range(num_stats):
+                activation = tensor[tt, i, s].numpy()   # [F, T]
+                plot_peak_time_histogram(
+                    activation=activation,
+                    layer=layer,
+                    stat_idx=s,
+                    out_dir=tt_dir,
+                    dpi=args.dpi,
+                )
 
-    total = 2 * L * num_stats
-    print(f"\nDone. {total} plots saved to: {args.out_dir}/")
+    total = num_token_types * 3 * L * num_stats  # sorted + unsorted heatmaps + histograms
+    print(f"\nDone. {total} plots saved under: {args.out_dir}/")
 
 
 if __name__ == "__main__":

--- a/visualize_activations.py
+++ b/visualize_activations.py
@@ -327,7 +327,7 @@ def main() -> None:
     print("Loading activation tensor...")
     tensor, layers = load_data(args)
 
-    # Support both old [L, 3, F, T] and new [2, L, 3, F, T] tensor shapes.
+    # Support both old [L, 4, F, T] and new [2, L, 4, F, T] tensor shapes.
     if tensor.ndim == 4:
         tensor = tensor.unsqueeze(0)
         token_type_names = ["all"]


### PR DESCRIPTION
Computes activation statistics separately for masked and unmasked tokens, outputting a tensor of shape [2, L, 3, F, T], and removes the T/3 and 2T/3 vertical reference lines from heatmaps so that diffusion stage boundaries can be identified from the features themselves. Also adds unsorted heatmaps to enable direct feature index comparison across plots.